### PR TITLE
REL-1526 - Fix context propagation for async communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,36 @@
-[![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Released Version][maven-img]][maven] [![Apache-2.0 license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+# Purpose
+This is overridden version of [opentracing-contrib/java-rabbitmq-client](https://github.com/opentracing-contrib/java-rabbitmq-client) that fixes library problems.
+Library is deprecated and not maintained anymore.
+It should replaced with OpenTelemetry.
 
-# OpenTracing RabbitMQ Client Instrumentation
-OpenTracing instrumentation for RabbitMQ Client.
+In the meantime, all fixes for SmartRecruiters will reside here.
 
-## Installation
-
-pom.xml
+# Publishing changes
+1. Adjust version in `pom.xml`
+2. Replace `{SR Nexus URL}` in `pom.xml` with URL to nexus
+3. Create settings for maven in `~/.m2/settings.xml
 ```xml
-<dependency>
-    <groupId>io.opentracing.contrib</groupId>
-    <artifactId>opentracing-rabbitmq-client</artifactId>
-    <version>VERSION</version>
-</dependency>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+    https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <localRepository/>
+    <interactiveMode/>
+    <usePluginRegistry/>
+    <offline/>
+    <pluginGroups/>
+    <servers>
+        <server>
+            <id>sr-nexus</id>
+            <username>*********************************************</username>
+            <password>*******************************</password>
+        </server>
+    </servers>
+    <mirrors/>
+    <proxies/>
+    <profiles/>
+    <activeProfiles/>
+</settings>
 ```
-
-## Usage
-
-
-```java
-// Instantiate tracer
-Tracer tracer = ...
-
-// Optionally register tracer with GlobalTracer
-GlobalTracer.register(tracer);
-
-// Decorate RabbitMQ Channel with TracingChannel
-TracingChannel tracingChannel = new TracingChannel(channel, tracer);
-
-// Send
-tracingChannel.basicPublish(...);
-
-// Get
-GetResponse response = tracingChannel.basicGet(queueName, false);
-
-// Consume
-tracingChannel.basicConsume(...);
-
-// Factory
-ConnectionFactory factory = new TracingConnectionFactory(tracer);
-Connection connection = factory.newConnection();
-
-```
-
-## License
-
-[Apache 2.0 License](./LICENSE).
-
-[ci-img]: https://travis-ci.org/opentracing-contrib/java-rabbitmq-client.svg?branch=master
-[ci]: https://travis-ci.org/opentracing-contrib/java-rabbitmq-client
-[cov-img]: https://coveralls.io/repos/github/opentracing-contrib/java-rabbitmq-client/badge.svg?branch=master
-[cov]: https://coveralls.io/github/opentracing-contrib/java-rabbitmq-client?branch=master
-[maven-img]: https://img.shields.io/maven-central/v/io.opentracing.contrib/opentracing-rabbitmq-client.svg
-[maven]: http://search.maven.org/#search%7Cga%7C1%7Copentracing-rabbitmq-client
+4. Run `mvn clean install`
+5. Run `mvn source:jar deploy`

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.opentracing.contrib</groupId>
   <artifactId>opentracing-rabbitmq-client</artifactId>
-  <version>0.1.12-SNAPSHOT</version>
+  <version>0.1.12-SR2</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>OpenTracing Instrumentation for RabbitMQ Client</description>
@@ -192,14 +192,9 @@
 
   <distributionManagement>
     <repository>
-      <id>bintray</id>
-      <url>https://api.bintray.com/maven/opentracing/maven/opentracing-rabbitmq-client/;publish=1
-      </url>
+      <id>sr-nexus</id>
+      <url>{SR Nexus URL}/repository/releases/</url>
     </repository>
-    <snapshotRepository>
-      <id>jfrog-snapshots</id>
-      <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
-    </snapshotRepository>
   </distributionManagement>
 
   <profiles>

--- a/src/main/java/io/opentracing/contrib/rabbitmq/HeadersMapInjectAdapter.java
+++ b/src/main/java/io/opentracing/contrib/rabbitmq/HeadersMapInjectAdapter.java
@@ -13,9 +13,11 @@
  */
 package io.opentracing.contrib.rabbitmq;
 
-import io.opentracing.propagation.TextMap;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+
+import io.opentracing.propagation.TextMap;
 
 
 public class HeadersMapInjectAdapter implements TextMap {
@@ -23,7 +25,9 @@ public class HeadersMapInjectAdapter implements TextMap {
   private final Map<String, Object> headers;
 
   public HeadersMapInjectAdapter(Map<String, Object> headers) {
-    this.headers = headers;
+    // CNC-194 - SR workaround for immutable headers map
+      // Version: opentracing-rabbitmq-client:0.1.12-SR1
+    this.headers = new HashMap<>(headers);
   }
 
   @Override

--- a/src/main/java/io/opentracing/contrib/rabbitmq/HeadersMapInjectAdapter.java
+++ b/src/main/java/io/opentracing/contrib/rabbitmq/HeadersMapInjectAdapter.java
@@ -13,7 +13,6 @@
  */
 package io.opentracing.contrib.rabbitmq;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -22,21 +21,25 @@ import io.opentracing.propagation.TextMap;
 
 public class HeadersMapInjectAdapter implements TextMap {
 
-  private final Map<String, Object> headers;
+    private final Map<String, Object> headers;
 
-  public HeadersMapInjectAdapter(Map<String, Object> headers) {
-    // CNC-194 - SR workaround for immutable headers map
-      // Version: opentracing-rabbitmq-client:0.1.12-SR1
-    this.headers = new HashMap<>(headers);
-  }
+    public HeadersMapInjectAdapter(Map<String, Object> headers) {
+        this.headers = headers;
+    }
 
-  @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    throw new UnsupportedOperationException("iterator should never be used with Tracer.inject()");
-  }
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator() {
+        throw new UnsupportedOperationException("iterator should never be used with Tracer.inject()");
+    }
 
-  @Override
-  public void put(String key, String value) {
-    headers.put(key, value);
-  }
+    @Override
+    public void put(String key, String value) {
+        // Version: opentracing-rabbitmq-client:0.1.12-SR2
+        try {
+            headers.put(key, value);
+        } catch (UnsupportedOperationException e) {
+            // Swallow the exception, headers are read only
+            // This code is most likely run on consumer side where rabbit mq headers are read only
+        }
+    }
 }


### PR DESCRIPTION
Previous fix was handling cases when trace context was restored from
event on consumer side. Due to unknown reasons this code that was
manipulating message headers was invoked (https://github
.com/opentracing-contrib/java-rabbitmq-client/blob/master/src/main/java
/io/opentracing/contrib/rabbitmq/TracingUtils.java#L67-L74).

Unfortunately, this fix was breaking injecting tracing context on
producer side, which effectively was killing context propagation.